### PR TITLE
Move black configs into pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
     -   id: black
         language: python
         types: [python]
-        args: ["--line-length=120"]
+        args: ["--config", "pyproject.toml"]

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ poetry install
 
 ## Run Tests
 
-```
+```bash
 poetry run pytest
 ```
 
 ## Setting up the precommit hook
 
-```
+```bash
 poetry run pre-commit sample-config > .pre-commit-config.yaml
 poetry run pre-commit install
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 pub_script = 'python_poetry_template.main:get_specific_bucket_objects'
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
# Description

We can move black configuration into the singular `pyproject.toml` file and then point the pre config at it. This makes sure that configs are all centralized in the python repo.

## How to test

Not sure i'd probably have to write some new python code and make sure the hook is still formatting it